### PR TITLE
Add workflow to push automatically on tag, releases, or certain branches

### DIFF
--- a/.github/workflows
+++ b/.github/workflows
@@ -1,0 +1,40 @@
+name: Build and Push Docker Image
+
+on:
+  release:
+    types: [published]
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: all
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PAT }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: docker.io/squedward/fromthepage:latest
+
+      - name: Log out from Docker Hub
+        run: docker logout

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -33,6 +33,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          file: Containerfile  # Specify the name of the container file
           push: true
           tags: docker.io/squedward/fromthepage:${{ github.ref_name }}
 

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -34,7 +34,6 @@ jobs:
         with:
           context: .
           push: true
-          tags: docker.io/squedward/fromthepage:latest
           tags: docker.io/squedward/fromthepage:${{ github.ref_name }}
 
       - name: Log out from Docker Hub

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -35,6 +35,7 @@ jobs:
           context: .
           push: true
           tags: docker.io/squedward/fromthepage:latest
+          tags: docker.io/squedward/fromthepage:${{ github.ref_name }}
 
       - name: Log out from Docker Hub
         run: docker logout

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -38,8 +38,8 @@ jobs:
           file: Containerfile
           push: true
           tags: |
-            docker.io/squedwards/fromthepage:latest
-            docker.io/squedwards/fromthepage:${{ github.ref_name }}
+            docker.io/bencomp/fromthepage:latest
+            docker.io/bencomp/fromthepage:${{ github.ref_name }}
 
       - name: Log out from Docker Hub
         run: docker logout

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -6,6 +6,8 @@ on:
   push:
     tags:
       - 'v*'
+    branches:
+      - 'actions*'
 
 jobs:
   build-and-push:

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
   push:
     tags:
-      - 'v*'
+      - '*'
     branches:
       - 'actions*'
 
@@ -35,9 +35,11 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: Containerfile  # Specify the name of the container file
+          file: Containerfile
           push: true
-          tags: docker.io/squedward/fromthepage:${{ github.ref_name }}
+          tags: |
+            docker.io/squedwards/fromthepage:latest
+            docker.io/squedwards/fromthepage:${{ github.ref_name }}
 
       - name: Log out from Docker Hub
         run: docker logout


### PR DESCRIPTION
With these changes  it should be possible to automatically push to the dockerhub registry on tags, releases, and branches that start with "actions". DOCKER_USERNAME and DOCKER_PAT need to be configured as secrets first.