### PR TITLE
Run the stats cronjob with production Rails env

### DIFF
--- a/fromthepage-stats.sh
+++ b/fromthepage-stats.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 . /home/app/fromthepage/load-secrets-to-env.sh
-cd /home/app/fromthepage && /sbin/setuser app bundle exec rake fromthepage:email_stats[24] >> /home/app/fromthepage/log/cron.log 2>&1
+cd /home/app/fromthepage && /sbin/setuser app RAILS_ENV=production bundle exec rake fromthepage:email_stats[24] >> /home/app/fromthepage/log/cron.log 2>&1


### PR DESCRIPTION
Update the email-the-stats script that is run in a daily cronjob to have the correct `RAILS_ENV`.