### PR TITLE
Use build stages more effectively

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -29,6 +29,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     pandoc \
     texlive-xetex \
     texlive-latex-base \
+    # texlive-extra-utils \
+    texlive-fonts-recommended \
+    lmodern \
     pdf2svg \
     poppler-utils \
     build-essential && \

--- a/Containerfile
+++ b/Containerfile
@@ -10,6 +10,12 @@ FROM ruby27-base AS ruby27
 LABEL org.opencontainers.image.authors="Ben Companjen <ben@companjen.name>"
 LABEL org.opencontainers.image.source="https://github.com/LeidenUniversityLibrary/fromthepage-podman"
 
+# Set the locale.
+RUN locale-gen en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
+
 # Install the Ubuntu packages.
 # Install Ruby, RubyGems, Bundler, ImageMagick, MySQL and Git
 # Install qt4/qtwebkit libraries for capybara
@@ -32,12 +38,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
       $(apt-get -s build-dep ruby-mysql2 | grep '^(Inst|Conf) ' | cut -d' ' -f2 | fgrep -v -e 'mysql-' -e 'ruby') && \
     DEBIAN_FRONTEND=noninteractive apt clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/cache/apt/archives/*
-
-# Set the locale.
-RUN locale-gen en_US.UTF-8
-ENV LANG=en_US.UTF-8
-ENV LANGUAGE=en_US:en
-ENV LC_ALL=en_US.UTF-8
 
 # --------------------
 FROM busybox AS src

--- a/Containerfile
+++ b/Containerfile
@@ -61,10 +61,10 @@ ARG BUNDLER_VERSION=2.4.22
 
 USER app
 WORKDIR /home/app
+RUN gem install bundler -v ${BUNDLER_VERSION}
 COPY --from=src --chown=app:app /fromthepage /home/app/fromthepage
 WORKDIR /home/app/fromthepage
 
-RUN gem install bundler -v ${BUNDLER_VERSION}
 
 # Install required gems
 # All gems are loaded on application startup, so we need to install them all

--- a/Containerfile
+++ b/Containerfile
@@ -77,7 +77,7 @@ WORKDIR /home/app/fromthepage
 # By setting the `deployment` flag, bundler install the gems within the app directory.
 # RUN bundle config set --local deployment 'true' && bundle install
 RUN bundle install --jobs 3
-RUN bundle exec rails assets:precompile
+RUN SECRET_KEY_BASE_DUMMY=1 bundle exec rails assets:precompile
 
 # ------------------
 FROM builder AS production

--- a/app_10-fromthepage.sh
+++ b/app_10-fromthepage.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 . /home/app/fromthepage/load-secrets-to-env.sh
-cd /home/app/fromthepage && /sbin/setuser app bundle exec rails db:prepare
+cd /home/app/fromthepage
+/sbin/setuser app bundle exec rails db:prepare


### PR DESCRIPTION
Closes #2 

This PR reshuffles build steps in the Containerfile, so that the same base image is used for building and running, with different apt package dependencies. A few unused gems are removed from the Gemfile before we `bundle install`, saving a few MBs.