### PR TITLE
Fix email stats script

### DIFF
--- a/fromthepage-stats.sh
+++ b/fromthepage-stats.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
+echo "Starting email stats at $(date)" >> /home/app/fromthepage/log/cron.log
 . /home/app/fromthepage/load-secrets-to-env.sh
 cd /home/app/fromthepage && /sbin/setuser app bundle exec rake fromthepage:email_stats[24] >> /home/app/fromthepage/log/cron.log 2>&1

--- a/fromthepage-stats.sh
+++ b/fromthepage-stats.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 . /home/app/fromthepage/load-secrets-to-env.sh
-cd /home/app/fromthepage && /sbin/setuser app RAILS_ENV=production bundle exec rake fromthepage:email_stats[24] >> /home/app/fromthepage/log/cron.log 2>&1
+cd /home/app/fromthepage && /sbin/setuser app bundle exec rake fromthepage:email_stats[24] >> /home/app/fromthepage/log/cron.log 2>&1


### PR DESCRIPTION
The syntax to run the rake task with `RAILS_ENV=production` doesn't work with `setuser`. #19 sets `RAILS_ENV` for the image (or it was already set), so if something doesn't work now, it isn't caused by this error.