### PR TITLE
Set USER root in final stage

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -100,6 +100,7 @@ RUN apt-get update -qq && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/cache/apt/archives/*
 
 COPY --from=build --chown=app:app /home/app/fromthepage /home/app/fromthepage
+USER root
 # Load nginx configuration
 RUN rm -f /etc/service/nginx/down /etc/nginx/sites-enabled/default
 ADD fromthepage-env.conf /etc/nginx/main.d/fromthepage-env.conf


### PR DESCRIPTION
I'm not sure if this is a Podman-related issue: when I ran v1.1.0 with `run -ti --userns=keep-id:uid=9999,gid=9999 docker.io/bencomp/fromthepage-passenger:nope` (`nope` because it didn't work), there was a file permission issue for `/etc/container_environment`.

When I run `run -ti --userns=keep-id:uid=9999,gid=9999 docker.io/bencomp/fromthepage-passenger:nope bash` I enter the container as the `app` user instead of `root`. In v1.0.1 we explicitly set `USER root` in the final build stage. Since that should have inherited the user from its parent stage, I figured it could be removed, even though in an intermediate stage we set `USER app`.

This hopefully tells Podman that the default user to start the container is root, not app.