### PR TITLE
Convert SMTP port to integer

### DIFF
--- a/production.rb
+++ b/production.rb
@@ -90,7 +90,7 @@ Rails.application.configure do
 
   config.action_mailer.smtp_settings = {
     address: ENV['SMTP_HOST'],
-    port:    ENV['SMTP_PORT'].to_i,
+    port:    Integer(ENV.fetch('SMTP_PORT', '25'), 10),
     domain:  ENV['FTP_HOSTNAME'],
     # other parameters include :user, :password, :authentication
   }

--- a/production.rb
+++ b/production.rb
@@ -90,7 +90,7 @@ Rails.application.configure do
 
   config.action_mailer.smtp_settings = {
     address: ENV['SMTP_HOST'],
-    port:    ENV['SMTP_PORT'],
+    port:    ENV['SMTP_PORT'].to_i,
     domain:  ENV['FTP_HOSTNAME'],
     # other parameters include :user, :password, :authentication
   }


### PR DESCRIPTION
Currently the port gets read as string, since it's retrieved as environment variable. This will convert it back to an integer.