### PR TITLE
Write environment to file, source it in cronjob

### DIFF
--- a/app_10-fromthepage.sh
+++ b/app_10-fromthepage.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
 . /home/app/fromthepage/load-secrets-to-env.sh
+declare -p | grep -E '^declare -x' > /etc/cron.env
 cd /home/app/fromthepage
 /sbin/setuser app bundle exec rails db:prepare

--- a/fromthepage-stats.sh
+++ b/fromthepage-stats.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
-echo "Starting email stats at $(date)" >> /home/app/fromthepage/log/cron.log
+setuser app echo "Starting email stats at $(date)" >> /home/app/fromthepage/log/cron.log
 . /home/app/fromthepage/load-secrets-to-env.sh
-cd /home/app/fromthepage && /sbin/setuser app bundle exec rake fromthepage:email_stats[24] >> /home/app/fromthepage/log/cron.log 2>&1
+. /etc/cron.env
+cd /home/app/fromthepage
+/sbin/setuser app bundle exec rake fromthepage:email_stats[24] >> /home/app/fromthepage/log/cron.log 2>&1


### PR DESCRIPTION
Closes #25 

When cron triggers scripts, the environment variables we need are not available by default. Based on [a comment on StackOverflow](https://stackoverflow.com/questions/27771781/how-can-i-access-docker-set-environment-variables-from-a-cron-job/41938139#comment103131339_48651061) we write the variables to a file during the container start and source those values from within the cronjob.