### PR TITLE
Set protocol to HTTPS in default URL options for production environment

### DIFF
--- a/production.rb
+++ b/production.rb
@@ -83,7 +83,7 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
-  Rails.application.routes.default_url_options[:host] = ENV['FTP_HOSTNAME']
+  Rails.application.routes.default_url_options = { host: ENV['FTP_HOSTNAME'], protocol: 'https' }
   config.action_mailer.default_url_options = { host: ENV['FTP_HOSTNAME'] }
   config.action_mailer.default_options = { from: ENV['FTP_SENDING_EMAIL_ADDRESS'] }
   config.action_mailer.delivery_method = :smtp


### PR DESCRIPTION
Some URLs appear to be created with `http://` instead of `https://`. However, this may have been the result of circumstance.