### PR TITLE
Optimise CI workflow

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -38,6 +38,8 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha
+            # set latest tag for default branch
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -10,6 +10,10 @@ on:
       - 'actions*'
       - 'main'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -5,9 +5,8 @@ on:
     types: [published]
   push:
     tags:
-      - '*'
+      - 'v*'
     branches:
-      - 'actions*'
       - 'main'
 
 concurrency:

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -52,6 +52,3 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Log out from Docker Hub
-        run: docker logout


### PR DESCRIPTION
We should only build one image at a time and don't really need each minor difference to become an image. Therefore we use a concurrency group and cancel in-progress workflows.

I want to set `latest` on the latest image; this add it to the set of tags if the build comes from the default branch.