### PR TITLE
Set the hostname and HTTPS for URLs created outside requests

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -36,6 +36,8 @@ RUN sed -i"" -e "s/^ruby.*$//" Gemfile
 # RUN echo 2.7.8 > .ruby-version
 RUN sed -i"" -E -e '/newrelic/d' -e '/capistrano/d' -e '/puma/d' Gemfile
 RUN echo "gem 'ffi', '< 1.17'" >> Gemfile
+RUN --mount=type=bind,source=patches/app_controller_renderer.patch,target=/fromthepage/app_controller_renderer.patch \
+    patch /fromthepage/config/initializers/application_controller_renderer.rb /fromthepage/app_controller_renderer.patch
 
 # --------------------
 FROM ruby27-base AS build

--- a/patches/app_controller_renderer.patch
+++ b/patches/app_controller_renderer.patch
@@ -1,0 +1,14 @@
+diff --git a/config/initializers/application_controller_renderer.rb b/config/initializers/application_controller_renderer.rb
+index 8c26c8a05..616328eed 100644
+--- a/config/initializers/application_controller_renderer.rb
++++ b/config/initializers/application_controller_renderer.rb
+@@ -2,7 +2,7 @@
+ 
+ ActiveSupport::Reloader.to_prepare do
+   ApplicationController.renderer.defaults.merge!(
+-	  http_host: 'fromthepage.com',
+-    https: false
++    http_host: ENV['FTP_HOSTNAME'],
++    https: Rails.env.production? ? Rails.application.config.force_ssl : true
+   )
+ end


### PR DESCRIPTION
Patch the application controller renderer initialiser. It may not be most efficient to look up the values every time the renderer is created, but it is flexible.