### PR TITLE
Escape parens in sed command

### DIFF
--- a/fix-routes.txt
+++ b/fix-routes.txt
@@ -1,7 +1,7 @@
 # sed script to update routes.rb
 
 # Fix the root route
-/root to:/ s|redirect('/landing')|'static#splash'|
+/root to:/ s|redirect\('/landing'\)|'static#splash'|
 /get '\/landing'/ s|'static#landing_page'|'static#splash'|
 
 # Remove "vanity URLs" for specific collections


### PR DESCRIPTION
It appears that we still have the default redirect from `/` to `/landing` in place in production. This is either caused by outdated configuration (which should soon be fixed after having merged #37) or because the regex did not escape the parentheses in the `sed` command. After escaping, the route is correctly updated.