### PR TITLE
Remove pricing info and trial sign-up, update config for recent upstream development

### DIFF
--- a/01fromthepage.rb
+++ b/01fromthepage.rb
@@ -41,3 +41,7 @@ OPENAI_ACCESS_TOKEN=ENV['OPENAI_ACCESS_TOKEN']
 
 ENABLE_TRANSKRIBUS=false
 TRANSKRIBUS_ACCESS_TOKEN=ENV['TRANSKRIBUS_ACCESS_TOKEN']
+
+GCV_ENABLED = false
+GCV_CREDENTIAL_FILE='/home/benwbrum/dev/products/fromthepage/integration/gcv/fromthepage-e2932d0557ba.json'
+OCR_TRANSFORM_COMMAND='docker run --rm -i ubma/ocr-fileformat ocr-transform gcv hocr | docker run --rm -i ubma/ocr-fileformat ocr-transform hocr alto4.0'

--- a/Containerfile
+++ b/Containerfile
@@ -16,7 +16,7 @@ ENV RAILS_ENV="production"
 ENV BUNDLE_PATH=/home/app/fromthepage/vendor/bundle
 
 # --------------------
-FROM busybox AS src
+FROM bitnami/git AS src
 ARG REPO=https://github.com/benwbrum/fromthepage.git
 ARG FTP_VERSION=development
 
@@ -37,9 +37,12 @@ RUN sed -i"" -e "s/^ruby.*$//" Gemfile
 RUN sed -i"" -E -e '/newrelic/d' -e '/capistrano/d' -e '/puma/d' Gemfile
 RUN echo "gem 'ffi', '< 1.17'" >> Gemfile
 RUN --mount=type=bind,source=patches/app_controller_renderer.patch,target=/fromthepage/app_controller_renderer.patch \
-    patch /fromthepage/config/initializers/application_controller_renderer.rb /fromthepage/app_controller_renderer.patch
+    git apply /fromthepage/app_controller_renderer.patch
 RUN --mount=type=bind,source=patches/owner_header.patch,target=/fromthepage/owner_header.patch \
-    patch /fromthepage/app/views/dashboard/_owner_header.html.slim /fromthepage/owner_header.patch
+    git apply /fromthepage/owner_header.patch
+RUN --mount=type=bind,source=patches/pricing.patch,target=/fromthepage/pricing.patch \
+    git apply /fromthepage/pricing.patch
+RUN rm app/views/static/pricing.html.slim
 
 # --------------------
 FROM ruby27-base AS build

--- a/Containerfile
+++ b/Containerfile
@@ -42,6 +42,8 @@ RUN --mount=type=bind,source=patches/owner_header.patch,target=/fromthepage/owne
     git apply /fromthepage/owner_header.patch
 RUN --mount=type=bind,source=patches/pricing.patch,target=/fromthepage/pricing.patch \
     git apply /fromthepage/pricing.patch
+RUN --mount=type=bind,source=patches/boot-logger.patch,target=/fromthepage/boot-logger.patch \
+    git apply /fromthepage/boot-logger.patch
 RUN rm app/views/static/pricing.html.slim
 
 # --------------------

--- a/Containerfile
+++ b/Containerfile
@@ -38,6 +38,8 @@ RUN sed -i"" -E -e '/newrelic/d' -e '/capistrano/d' -e '/puma/d' Gemfile
 RUN echo "gem 'ffi', '< 1.17'" >> Gemfile
 RUN --mount=type=bind,source=patches/app_controller_renderer.patch,target=/fromthepage/app_controller_renderer.patch \
     patch /fromthepage/config/initializers/application_controller_renderer.rb /fromthepage/app_controller_renderer.patch
+RUN --mount=type=bind,source=patches/owner_header.patch,target=/fromthepage/owner_header.patch \
+    patch /fromthepage/app/views/dashboard/_owner_header.html.slim /fromthepage/owner_header.patch
 
 # --------------------
 FROM ruby27-base AS build

--- a/fix-routes.txt
+++ b/fix-routes.txt
@@ -7,6 +7,9 @@
 # Remove "vanity URLs" for specific collections
 /:collection_id =>/d
 
+# Remove route for pricing
+/'pricing'/d
+
 # Remove routes for success stories
 /static#at/d
 /static#natsstory/d

--- a/fix-routes.txt
+++ b/fix-routes.txt
@@ -7,8 +7,9 @@
 # Remove "vanity URLs" for specific collections
 /:collection_id =>/d
 
-# Remove route for pricing
+# Remove routes for pricing and new trial
 /'pricing'/d
+/trial/d
 
 # Remove routes for success stories
 /static#at/d

--- a/patches/boot-logger.patch
+++ b/patches/boot-logger.patch
@@ -1,0 +1,11 @@
+diff --git a/config/boot.rb b/config/boot.rb
+index b9e460cef..4cd8cfffe 100644
+--- a/config/boot.rb
++++ b/config/boot.rb
+@@ -1,4 +1,6 @@
+ ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
+ 
+ require 'bundler/setup' # Set up gems listed in the Gemfile.
++# Fix from https://stackoverflow.com/a/79379493/1445526
++require "logger" # Fix concurrent-ruby removing logger dependency which Rails itself does not have
+ require 'bootsnap/setup' # Speed up boot time by caching expensive operations.

--- a/patches/owner_header.patch
+++ b/patches/owner_header.patch
@@ -1,0 +1,31 @@
+diff --git a/app/views/dashboard/_owner_header.html.slim b/app/views/dashboard/_owner_header.html.slim
+index 2be00fe0d..a000cfd7f 100644
+--- a/app/views/dashboard/_owner_header.html.slim
++++ b/app/views/dashboard/_owner_header.html.slim
+@@ -38,26 +38,6 @@
+         -unless current_user.all_owner_collections.empty?
+         =link_to t('.create_a_collection'), collection_new_path, data: { controller: 'litebox', litebox: { hash: 'create-collection' } }
+ 
+--if !(current_user.account_type == nil)
+-  .owner-info
+-    -account_type_key = current_user.account_type.downcase.tr(' ', '_')
+-    =t('.account_type', type: t(".account_types.#{account_type_key}"))
+-    -unless (current_user.start_date == nil)
+-      span
+-        |&nbsp;
+-        =t('.since', date: l(current_user.start_date.to_date))
+-    -unless (current_user.paid_date == nil)
+-      span
+-        |&nbsp;&middot;&nbsp;
+-        =t('.current_subscription_expires', date: l(current_user.paid_date.to_date))
+-    span
+-      |&nbsp;&middot;&nbsp;
+-      =t('.total_pages', pages: current_user.page_count)
+-    -if (current_user.account_type == 'Trial') && UPGRADE_FORM_LINK
+-      span
+-        |&nbsp;&nbsp;
+-        =link_to t('.upgrade'), UPGRADE_FORM_LINK, class: 'button outline', target: '_blank'
+-
+ section.owner-counters
+   .counter(data-prefix="#{number_with_delimiter @collections.length}") =t('.collection', count: @collections.length)
+   .counter(data-prefix="#{number_with_delimiter @works.length}") =t('.work', count: @works.length)

--- a/patches/pricing.patch
+++ b/patches/pricing.patch
@@ -1,0 +1,123 @@
+diff --git a/app/assets/stylesheets/sections/software.scss b/app/assets/stylesheets/sections/software.scss
+index 5124d016c..fe9615028 100644
+--- a/app/assets/stylesheets/sections/software.scss
++++ b/app/assets/stylesheets/sections/software.scss
+@@ -97,30 +97,6 @@
+     }
+   }
+ 
+-  #pricing {
+-    clear: both;
+-    margin-top: $gapSize * 3;
+-
+-    h2 { margin-bottom: $gapSize * 2; }
+-    h3 { text-align: center; }
+-
+-    ul.pricing_features {
+-      list-style: none;
+-      margin-left: 0;
+-
+-      li strong {
+-        font-weight: bold;
+-      }
+-    }
+-
+-    .pricing_grid_cell .pricing_price .pricing_price_billing {
+-      display: block;
+-      font-size: $fontSize;
+-      width: 100%;
+-      margin: 13px 0 $gapSize 0;
+-    }
+-  }
+-
+   #integrations {
+     section {
+       width: 33%;
+diff --git a/app/views/static/software.html.slim b/app/views/static/software.html.slim
+index 15c5f4725..67a8b396b 100644
+--- a/app/views/static/software.html.slim
++++ b/app/views/static/software.html.slim
+@@ -47,83 +47,6 @@
+     #video_wrapper
+       <iframe title="Get Started" width="560" height="315" src="https://www.youtube.com/embed/UcNXSY0q9uE?controls=0" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+ 
+-  section#pricing
+-    h2 FromThePage Pricing
+-
+-    .pricing
+-      .pricing_grid
+-        .pricing_grid_row
+-          .pricing_grid_cell
+-            h4.pricing_title Researcher
+-            ul.pricing_features
+-              li.pricing_feature Collaborative transcription, translation, OCR correction and subject indexing
+-              li.pricing_feature Multiple export formats (TEI, CSV, HTML, IIIF/Open Annotation)
+-              li.pricing_feature 1 project
+-              li.pricing_feature Unlimited documents
+-              li.pricing_feature Up to 10,000 pages
+-              li.pricing_feature E-mail support
+-              li.pricing_feature Your data will be available as read-only and can be exported if you cancel your subscription.
+-              li.pricing_feature Credit Card Required
+-          .pricing_grid_cell
+-            h4.pricing_title Small Organization
+-            ul.pricing_features
+-              li.pricing_feature Collaborative transcription, translation, OCR correction and subject indexing
+-              li.pricing_feature Multiple export formats (TEI, CSV, HTML, IIIF/Open Annotation)
+-              li.pricing_feature Unlimited projects
+-              li.pricing_feature Unlimited documents
+-              li.pricing_feature Up to 50,000 pages
+-              li.pricing_feature E-mail and chat support
+-              li.pricing_feature Phone consultation on new projects
+-              li.pricing_feature Your data will be available as read-only and can be exported if you cancel your subscription.
+-          .pricing_grid_cell
+-            h4.pricing_title Large Institution
+-            ul.pricing_features
+-              li.pricing_feature Collaborative transcription, translation, subject indexing, and OCR correction
+-              li.pricing_feature Multiple export formats (TEI, CSV, HTML, IIIF/Open Annotation)
+-              li.pricing_feature Unlimited projects
+-              li.pricing_feature Unlimited documents
+-              li.pricing_feature Up to 100,000 pages
+-              li.pricing_feature Contact us for pricing for additional pages
+-              li.pricing_feature E-mail and chat support
+-              li.pricing_feature Phone consultation on new projects and strategic consultation
+-              li.pricing_feature Your data will be available as read-only and can be exported if you cancel your subscription.
+-              li.pricing_feature
+-                strong PLUS
+-              li.pricing_feature Single Sign On
+-              li.pricing_feature On Demand Custom Reports
+-              li.pricing_feature IIIF Consulting
+-              li.pricing_feature Integration Consulting
+-        .pricing_grid_row
+-          .pricing_grid_cell
+-            .pricing_price
+-              span.pricing_price_value $100
+-              .pricing_price_billing per month, billed monthly or
+-              span.pricing_price_value $1200
+-              .pricing_price_billing per year, billed annually
+-          .pricing_grid_cell
+-            .pricing_price
+-              span.pricing_price_value $360
+-              .pricing_price_billing per month, billed monthly or 
+-              span.pricing_price_value $3600
+-              .pricing_price_billing per year, billed annually
+-          .pricing_grid_cell
+-            .pricing_price
+-              span.pricing_price_value $600
+-              .pricing_price_billing per month, billed monthly or 
+-              span.pricing_price_value $6000
+-              .pricing_price_billing per year, billed annually
+-
+-        .pricing_grid_row
+-          .pricing_grid_cell
+-            =link_to 'Start Free Trial', users_new_trial_path, class: 'button big'
+-          .pricing_grid_cell
+-            =link_to 'Start Free Trial', users_new_trial_path, class: 'button big'
+-          .pricing_grid_cell
+-            =link_to 'Start Free Trial', users_new_trial_path, class: 'button big'
+-
+-    h3 Ready to buy?  
+-    p #{link_to('Send us a note', contact_path(contact_form_token))} and we'll send you an invoice, payable either by credit card or by your organization's accounting department.  Need additional paperwork for a PO?  Just let us know.
+-
+   #integrations
+     h2 Integrations
+ 


### PR DESCRIPTION
This closes #39 

All changes:

- use the bitnami/git Docker image to prepare the upstream code, because it allows `git apply`
- `require logger` in `boot.rb`, because Bundler may install `concurrent-ruby` 1.3.5 that no longer does it, causing a `NameError` in ActiveSupport
- remove routes and code that allowed people to register for a trial; remove code that shows (trial) registration and renewal information
- add new constants to the `01fromthepage.rb` initializer that relate to Google Cloud Vision (and disable GCV)